### PR TITLE
European characters breaking when running on SymPy repo

### DIFF
--- a/git2json/__init__.py
+++ b/git2json/__init__.py
@@ -177,11 +177,11 @@ def parse_commits(lines):
 
 def git2jsons(s):
     lines = s.split('\n')
-    return json.dumps(parse_commits(lines))
+    return json.dumps(parse_commits(lines), ensure_ascii=False)
 
 
 def git2json(fil):
-    return json.dumps(parse_commits(fil))
+    return json.dumps(parse_commits(fil), ensure_ascii=False)
 
 
 def run_git_log(git_dir=None):


### PR DESCRIPTION
``` pytb
$git2json --git-dir=/Users/aaronmeurer/Documents/Python/sympy/sympy/.git > sympy-log.json
Traceback (most recent call last):
  File "/Users/aaronmeurer/anaconda3/envs/python2/bin/git2json", line 6, in <module>
    sys.exit(main())
  File "/Users/aaronmeurer/anaconda3/envs/python2/lib/python2.7/site-packages/git2json/__init__.py", line 219, in main
    print git2json(run_git_log(args.git_dir))
  File "/Users/aaronmeurer/anaconda3/envs/python2/lib/python2.7/site-packages/git2json/__init__.py", line 184, in git2json
    return json.dumps(parse_commits(fil))
  File "/Users/aaronmeurer/anaconda3/envs/python2/lib/python2.7/json/__init__.py", line 243, in dumps
    return _default_encoder.encode(obj)
  File "/Users/aaronmeurer/anaconda3/envs/python2/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Users/aaronmeurer/anaconda3/envs/python2/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xce in position 11: invalid continuation byte
```
