### PR TITLE
solving compatibility issues for python3 and windows

### DIFF
--- a/git2json/__init__.py
+++ b/git2json/__init__.py
@@ -87,7 +87,7 @@ def parse_numstat_line(line):
 
 
 def parse_blank_line(line):
-    if len(line) == 1 and line == '\n':
+    if len(line)==0 or (len(line) == 1 and line == '\n'):
         return True
     else:
         return None
@@ -229,4 +229,7 @@ def main():
         help='Path to the .git/ directory of the repository you are targeting'
     )
     args = parser.parse_args()
-    print (git2json(run_git_log(args.git_dir)))
+    if sys.version_info < (3, 0):
+        print (git2json(run_git_log(args.git_dir)))
+    else:
+        print (git2jsons(run_git_log(args.git_dir)))


### PR DESCRIPTION
after a long hunt, I finally got it working, under python3+ windows.

log = json.load(open('ipython-log.json'))
print ("Number of commits = ", len(log));print (log[0])

Number of commits =  11964
{'author': {'date': 1377906000, 'name': 'Brian E. Granger', 'email': 'ellisonbg@gmail.com', 'timezone': '-0700'}, 'tree': 'f36455dce03a8e2e160f276e2ba1a5fff007c82d', 'commit': '9f92804762878b36b81885dccd9f44172b6cb18c', 'committer': {'date': 1377906000, 'name': 'Brian E. Granger', 'email': 'ellisonbg@gmail.com', 'timezone': '-0700'}, 'changes': [], 'message': 'Merge pull request #4090 from ellisonbg/citationAdd LaTeX citation handling to nbconvert', 'parents': ['6eb7d86707a0d35a3eb24c0aeaef0403630a8fa3', '99bb6f007c75a1af524a3bf6dd52ee22a84aa60d']}
