### PR TITLE
Fix Issue 11, Parser Will Handle Empty Commit Messages

### DIFF
--- a/git2json/parser.py
+++ b/git2json/parser.py
@@ -67,11 +67,7 @@ def parse_commit(parts):
     ]
     commit['author'] = parse_author_line(parts['author'])
     commit['committer'] = parse_committer_line(parts['committer'])
-    commit['message'] = "\n".join(
-        parse_message_line(msgline)
-        for msgline in
-        parts['message'].splitlines()
-    )
+    commit['message'] = parse_message(parts['message'])
     commit['changes'] = [
         parse_numstat_line(numstat)
         for numstat in
@@ -133,13 +129,13 @@ def parse_author_line(line):
     return parse_person_line(line, 'author')
 
 
-def parse_message_line(line):
-    RE_MESSAGE = r'    (.*)'
-    result = re.match(RE_MESSAGE, line)
-    if result is None:
-        return result
+def parse_message(message):
+    RE_MESSAGE = re.compile(r'^    ', re.MULTILINE)
+    result = re.sub(RE_MESSAGE, '', message)
+    if not result or result.isspace():
+        return None
     else:
-        return result.groups()[0]
+        return result
 
 
 def parse_numstat_line(line):

--- a/tests/fixtures/test_git2json-3.txt
+++ b/tests/fixtures/test_git2json-3.txt
@@ -1,0 +1,13 @@
+commit e04818d1b8de44d47003031791f142182320ed89
+tree 3f56c6c53f914a2ed882e32a8a3438be619f8f17
+parent 6cbec586731b7c5f293f2a7b6c7330c7181acdfe
+author Jeremy Kemper <jeremy@bitsweat.net> 1348081584 -0700
+committer Jeremy Kemper <jeremy@bitsweat.net> 1348081584 -0700
+
+    Revert "Make sure :environment task is executed before db:schema:load or db:structure:load"
+    
+    Breaks db:setup because it tries to load the environment before creating the database.
+    
+    This reverts commit 5ca11fefce6d83f5db399aa4412f1f1a0d42b2e6.
+
+2	2	activerecord/lib/active_record/railties/databases.rake

--- a/tests/test_git2json.py
+++ b/tests/test_git2json.py
@@ -73,3 +73,17 @@ def reg_test_7_hidden_files():
     second_change = changes[1]
     fname = second_change[2]
     eq_(fname, '.travis.yml')
+
+
+def reg_test_empty_lines():
+    '''Ensure commits with empty lines do not crash
+    git2json'''
+
+    fixture = open(get_tst_path() + 'fixtures/test_git2json-3.txt')
+
+    try:
+        commits = list(git2json.parse_commits(fixture.read()))
+    except TypeError:
+        assert False, 'Parsing commit with an empty line raised a TypeError.'
+
+    eq_(len(commits), 1)


### PR DESCRIPTION
This PR changes `parse_message_line` to `parse_message`. 

`parse_message` does a couple things differently. It parses the whole commit rather than just a line. It also removes the whitespace formatting from the string, as opposed to selecting the "text" portion of the string.

Once it has removed the whitespace from all the lines, then it makes a decision about whether this commit message is empty. If it decides it is, then it returns None.
