### PR TITLE
Fix non-toplevel imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ install:
 
 # command to run tests, e.g. python setup.py test
 script:
-  - python setup.py nosetests --with-coverage
+  - python setup.py nosetests
   - flake8 git2json
   - flake8 tests
-after_success:
-  - coveralls

--- a/git2json/__init__.py
+++ b/git2json/__init__.py
@@ -5,15 +5,13 @@ Generate a json log of a git repository.
 """
 
 from __future__ import print_function
+import json
+import sys
+from .parser import parse_commits
 
 __author__ = 'Tavish Armstrong'
 __email__ = 'tavisharmstrong@gmail.com'
 __version__ = '0.2.3'
-
-
-import json
-import sys
-from .parser import parse_commits
 
 # -------------------------------------------------------------------
 # Main

--- a/git2json/parser.py
+++ b/git2json/parser.py
@@ -9,11 +9,11 @@ These parsing functions expect output of the following command:
 
 """
 
+import re
+
 __author__ = 'Tavish Armstrong'
 __email__ = 'tavisharmstrong@gmail.com'
 __version__ = '0.2.1'
-
-import re
 
 PAT_COMMIT = r'''
 (


### PR DESCRIPTION
The build on https://github.com/tarmstrong/git2json/pull/12 was failing because of problems with updates to flake8. This PR fixes those flake8 style problems.

(Ideally I would just pin the flake8 rules git2json uses but I'm not going to shave that yak right now.)