### PR TITLE
Add since arg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,12 +40,17 @@ Usage
 
 ::
 
-    usage: git2json [-h] [--git-dir GIT_DIR]
+    usage: git2json [-h] [--git-dir GIT_DIR] [--since SINCE]
 
     optional arguments:
       -h, --help         show this help message and exit
       --git-dir GIT_DIR  Path to the .git/ directory of the repository you are
-                        targeting
+                         targeting
+      --since SINCE      Show commits more recent than a specific date. If
+                         present, this argument is passed through to "git log"
+                         unchecked.
+
+    usage: git2json [-h] [--git-dir GIT_DIR]
 
 
 The resulting JSON log is printed to standard output.

--- a/git2json/__init__.py
+++ b/git2json/__init__.py
@@ -25,11 +25,17 @@ def main():
         default=None,
         help='Path to the .git/ directory of the repository you are targeting'
     )
+    parser.add_argument(
+        '--since',
+        default=None,
+        help=('Show commits more recent than a specific date. If present, this '
+              'argument is passed through to "git log" unchecked. ')
+    )
     args = parser.parse_args()
     if sys.version_info < (3, 0):
-        print(git2json(run_git_log(args.git_dir)))
+        print(git2json(run_git_log(args.git_dir, args.since)))
     else:
-        print(git2jsons(run_git_log(args.git_dir)))
+        print(git2jsons(run_git_log(args.git_dir, args.since)))
 
 # -------------------------------------------------------------------
 # Main API functions
@@ -47,7 +53,7 @@ def git2json(fil):
 # Functions for interfacing with git
 
 
-def run_git_log(git_dir=None):
+def run_git_log(git_dir=None, git_since=None):
     '''run_git_log([git_dir]) -> File
 
     Run `git log --numstat --pretty=raw` on the specified
@@ -63,6 +69,8 @@ def run_git_log(git_dir=None):
         ]
     else:
         command = ['git', 'log', '--numstat', '--pretty=raw']
+    if git_since is not None:
+        command.append('--since=' + git_since)
     raw_git_log = subprocess.Popen(
         command,
         stdout=subprocess.PIPE

--- a/git2json/__init__.py
+++ b/git2json/__init__.py
@@ -28,8 +28,8 @@ def main():
     parser.add_argument(
         '--since',
         default=None,
-        help=('Show commits more recent than a specific date. If present, this '
-              'argument is passed through to "git log" unchecked. ')
+        help=('Show commits more recent than a specific date. If present, '
+              'this argument is passed through to "git log" unchecked. ')
     )
     args = parser.parse_args()
     if sys.version_info < (3, 0):


### PR DESCRIPTION
git2json is quite helpful.  I'm using it to look at gerrit usage for our team.  But our repo log is git large (80K commits over 20+ years), so need to be able to limit log size.  Adding --since argument and passing onto git log in this pull request.