### PR TITLE
Remove --use-mirrors that does not seem to exist any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,14 @@ language: python
 
 python:
   - "2.7"
-  - "2.6"
-  - "3.2"
   - "3.3"
+  - "3.6"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install -r requirements.txt --use-mirrors
-  - pip install flake8 --use-mirrors
-  - pip install python-coveralls --use-mirrors
+  - pip install -r requirements.txt
+  - pip install flake8
+  - pip install python-coveralls
 
 # command to run tests, e.g. python setup.py test
 script:


### PR DESCRIPTION
* Removes `--use-mirrors` option that does not work any more
* Removes outdated (I think?) python versions from the travis CI config