### PR TITLE
Add: #19 "--args" argument to pass argument log command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ Usage
       --since SINCE      Show commits more recent than a specific date. If
                          present, this argument is passed through to "git log"
                          unchecked.
+      --args SRCS        Pass additional arguments to git log
 
     usage: git2json [-h] [--git-dir GIT_DIR]
 

--- a/git2json/__init__.py
+++ b/git2json/__init__.py
@@ -31,11 +31,17 @@ def main():
         help=('Show commits more recent than a specific date. If present, '
               'this argument is passed through to "git log" unchecked. ')
     )
+    parser.add_argument(
+        '--args',
+        default=None,
+        help=('Pass additional args to the log message,'
+              'this argument is passed through to "git log" unchecked. ')
+    )
     args = parser.parse_args()
     if sys.version_info < (3, 0):
-        print(git2json(run_git_log(args.git_dir, args.since)))
+        print(git2json(run_git_log(args.git_dir, args.since, args.args)))
     else:
-        print(git2jsons(run_git_log(args.git_dir, args.since)))
+        print(git2jsons(run_git_log(args.git_dir, args.since, args.args)))
 
 # -------------------------------------------------------------------
 # Main API functions
@@ -53,7 +59,7 @@ def git2json(fil):
 # Functions for interfacing with git
 
 
-def run_git_log(git_dir=None, git_since=None):
+def run_git_log(git_dir=None, git_since=None, git_args=None):
     '''run_git_log([git_dir]) -> File
 
     Run `git log --numstat --pretty=raw` on the specified
@@ -71,6 +77,8 @@ def run_git_log(git_dir=None, git_since=None):
         command = ['git', 'log', '--numstat', '--pretty=raw']
     if git_since is not None:
         command.append('--since=' + git_since)
+    if git_args is not None:
+        command.append(git_args)
     raw_git_log = subprocess.Popen(
         command,
         stdout=subprocess.PIPE


### PR DESCRIPTION
For generating logs between 2 tags or sha1's we need to pass additonal
arguments to the git log command. Add a command line argument that will
be passed onto the git log in addition to the arguments that are needed
for git2json