### PR TITLE
Fixed an exception that occurs when parse_message_line receives empty string

### DIFF
--- a/git2json/parser.py
+++ b/git2json/parser.py
@@ -143,7 +143,7 @@ def parse_message_line(line):
     RE_MESSAGE = r'    (.*)'
     result = re.match(RE_MESSAGE, line)
     if result is None:
-        return result
+        return ""
     else:
         return result.groups()[0]
 


### PR DESCRIPTION
Hi 😄 ,
an exception occured to me when ```parse_message_line``` receives an empty string.
When this occurs, ```parse_message_line``` returns None.
After that, ```"\n".join``` throws an exception when one of the members of the list is none.

Example to an input that causes this is:
```
parts['message']='    Adding titles to links\n    \u2028\n'
```

The fix is simple, replace None with empty string.
