### PR TITLE
Fixed parse_message_line error

### DIFF
--- a/git2json/parser.py
+++ b/git2json/parser.py
@@ -143,7 +143,7 @@ def parse_message_line(line):
     RE_MESSAGE = r'    (.*)'
     result = re.match(RE_MESSAGE, line)
     if result is None:
-        return result
+        return "\n"
     else:
         return result.groups()[0]
 


### PR DESCRIPTION
When the code in parser.py:70 is called:
```
 commit['message'] = "\n".join(
        parse_message_line(msgline)
        for msgline in
        parts['message'].splitlines()
    )
```

and `parse_message_line` is returned as None, and exception is thrown.
The solution was simple, swap None with newline.